### PR TITLE
Fixing this error by using powershell instead of defaulting to cmd

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -64,6 +64,7 @@ resource "null_resource" "file_uploads" {
 
   provisioner "local-exec" {
     command = "cd ${path.root}/files; az storage file upload-batch --account-name ${azurerm_storage_account.bootstrap-storage-acct.name} --account-key ${azurerm_storage_account.bootstrap-storage-acct.primary_access_key} --source . --destination ${azurerm_storage_share.bootstrap-storage-share.name}"
+    interpreter = ["PowerShell", "-Command"]
   }
 }
 


### PR DESCRIPTION
module.panos-bootstrap.null_resource.file_uploads (local-exec): Executing: ["cmd" "/C" "cd ./files; az storage file upload-batch --account-name bootstrapacct44790 --account-key /Hunhca/G2IaJqDubdyUpDWNC3y+lKV25oiIebPUchtuYljSdg6Ah/rdbvrDMGtiqWKDVWDVv33dv9ePxebIVA== --source . --destination bootstrapshare44790"]
module.panos-bootstrap.null_resource.file_uploads (local-exec): The system cannot find the path specified.


Error: Error running command 'cd ./files; az storage file upload-batch --account-name bootstrapacct44790 --account-key /Hunhca/G2IaJqDubdyUpDWNC3y+lKV25oiIebPUchtuYljSdg6Ah/rdbvrDMGtiqWKDVWDVv33dv9ePxebIVA== --source . --destination bootstrapshare44790': exit status 1. Output: The system cannot find the path specified.

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
